### PR TITLE
Faster interaction with the AWS login page

### DIFF
--- a/background.js
+++ b/background.js
@@ -52,7 +52,7 @@ async function checkAndLogin(tabId) {
             const allowButton = await waitForElement(() => {
                 const button = document.querySelector('button[data-testid="allow-access-button"]');
 
-                if (button?.textContent.toLowerCase().includes('allow access')) {
+                if (button?.textContent.toLowerCase().includes('allow')) {
                     return button;
                 }
             });


### PR DESCRIPTION
Poll for HTML elements instead of relying on a delay of 1.5 seconds. 

The polling will also stop in 1.5 seconds, but the click and closing of the tab will be performed as early as the elements are present in the DOM.


Nice extension btw, was planning to implement something like this myself, but I found yours first 🤓 